### PR TITLE
allow client provided account name

### DIFF
--- a/internal/pkg/api/v1/credentials_test.go
+++ b/internal/pkg/api/v1/credentials_test.go
@@ -20,6 +20,7 @@ var _ = Describe("Credentials", func() {
 			uri = svr.URL + "/v1/credentials"
 			body.Write([]byte(payloadRequestCredentials))
 			createRequest(http.MethodPost)
+			// This is required for the success case.
 			fakeSQLClient.GetCredentialsReturns(cloudrunner.Credentials{}, sql.ErrCredentialsNotFound)
 		})
 
@@ -109,6 +110,19 @@ var _ = Describe("Credentials", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				validateResponse(payloadErrorCreatingWritePermission)
+			})
+		})
+
+		When("the account is not defined", func() {
+			BeforeEach(func() {
+				body = &bytes.Buffer{}
+				body.Write([]byte(`{"projectID": "test-project-id"}`))
+				createRequest(http.MethodPost)
+			})
+
+			It("generates the account name", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusCreated))
+				validateResponse(payloadCredentialsCreatedNoAccountProvided)
 			})
 		})
 
@@ -248,7 +262,7 @@ var _ = Describe("Credentials", func() {
 		When("it gets the credentials", func() {
 			It("returns status OK", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusOK))
-				validateResponse(payloadCredentialsCreated)
+				validateResponse(payloadCredentials)
 			})
 		})
 	})

--- a/internal/pkg/api/v1/payload_test.go
+++ b/internal/pkg/api/v1/payload_test.go
@@ -5,6 +5,7 @@ const payloadBadRequest = `{
           }`
 
 const payloadRequestCredentials = `{
+            "account": "test-account",
 						"projectID": "test-project-id",
 						"readGroups": [
 							"gg_test"
@@ -57,8 +58,24 @@ const payloadUnauthorized = `{
             "error": "X-Spinnaker-User header not set"
           }`
 
-const payloadCredentialsCreated = `{
+const payloadCredentials = `{
             "account": "cr-test-project-id",
+            "projectID": "test-project-id",
+            "readGroups": [
+              "gg_test"
+            ],
+            "writeGroups": [
+              "gg_test"
+            ]
+          }`
+
+const payloadCredentialsCreatedNoAccountProvided = `{
+            "account": "cr-test-project-id",
+            "projectID": "test-project-id"
+          }`
+
+const payloadCredentialsCreated = `{
+            "account": "test-account",
             "projectID": "test-project-id",
             "readGroups": [
               "gg_test"

--- a/pkg/credentials.go
+++ b/pkg/credentials.go
@@ -3,6 +3,6 @@ package cloudrunner
 type Credentials struct {
 	Account     string   `json:"account" gorm:"primary_key"`
 	ProjectID   string   `json:"projectID"`
-	ReadGroups  []string `json:"readGroups" gorm:"-"`
-	WriteGroups []string `json:"writeGroups" gorm:"-"`
+	ReadGroups  []string `json:"readGroups,omitempty" gorm:"-"`
+	WriteGroups []string `json:"writeGroups,omitempty" gorm:"-"`
 }


### PR DESCRIPTION
- allow clients to provide the account name
- if no account name is provided generate one in the format `cr-<GCP_PROJECT_ID>`