### PR TITLE
add spinnaker user header to deployments POST

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -35,7 +35,7 @@ paths:
         schema:
           $ref: "#/definitions/DeploymentDescription"
       - in: "header"
-        name: "apiKey"
+        name: "API-Key"
         description: "API Key required for create operations"
         type: "string"
         required: true
@@ -156,7 +156,7 @@ paths:
         schema:
           $ref: "#/definitions/Credentials"
       - in: "header"
-        name: "apiKey"
+        name: "API-Key"
         description: "API Key required for create operations"
         type: "string"
         required: true

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -39,6 +39,11 @@ paths:
         description: "API Key required for create operations"
         type: "string"
         required: true
+      - name: "X-Spinnaker-User"
+        in: "header"
+        description: "The user making the request"
+        required: true
+        type: "string"
       responses:
         "201":
           description: "Deployment created"
@@ -329,5 +334,3 @@ definitions:
       import:
         package: time
         alias: time
-
-


### PR DESCRIPTION
- adds the `X-Spinnaker-User` required header to the `POST /v1/deployments` endpoint