### PR TITLE
use Gin binding tag in favor of manually checking for project ID

### DIFF
--- a/internal/api/v1/credentials.go
+++ b/internal/api/v1/credentials.go
@@ -25,12 +25,6 @@ func CreateCredentials(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-
-	if creds.ProjectID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "project ID required"})
-		return
-	}
-
 	// If an account name was not provided, generate one.
 	if creds.Account == "" {
 		creds.Account = fmt.Sprintf("cr-%s", creds.ProjectID)

--- a/internal/api/v1/payload_test.go
+++ b/internal/api/v1/payload_test.go
@@ -31,7 +31,7 @@ const payloadConflictRequest = `{
           }`
 
 const payloadProjectIDRequired = `{
-            "error": "project ID required"
+            "error": "Key: 'Credentials.ProjectID' Error:Field validation for 'ProjectID' failed on the 'required' tag"
           }`
 
 const payloadGenericError = `{

--- a/pkg/credentials.go
+++ b/pkg/credentials.go
@@ -2,7 +2,7 @@ package cloudrunner
 
 type Credentials struct {
 	Account     string   `json:"account" gorm:"primary_key"`
-	ProjectID   string   `json:"projectID"`
+	ProjectID   string   `json:"projectID" binding:"required"`
 	ReadGroups  []string `json:"readGroups,omitempty" gorm:"-"`
 	WriteGroups []string `json:"writeGroups,omitempty" gorm:"-"`
 }


### PR DESCRIPTION
- remove code to check for required field `projectID` when creating credentials in favor of using Gin's `required` binding struct tag