### PR TITLE
merge write groups into read groups

### DIFF
--- a/internal/api/v1/payload_test.go
+++ b/internal/api/v1/payload_test.go
@@ -15,6 +15,18 @@ const payloadRequestCredentials = `{
 						]
           }`
 
+const payloadRequestCredentialsMismatchedGroups = `{
+            "account": "test-account",
+						"projectID": "test-project-id",
+						"readGroups": [
+							"gg_test1"
+						],
+						"writeGroups": [
+							"gg_test1",
+							"gg_test2"
+						]
+          }`
+
 const payloadRequestDeployment = `{
 						"account": "cr-test-project-id",
 						"allowUnauthenticated": false,
@@ -72,6 +84,19 @@ const payloadCredentials = `{
 const payloadCredentialsCreatedNoAccountProvided = `{
             "account": "cr-test-project-id",
             "projectID": "test-project-id"
+          }`
+
+const payloadCredentialsCreatedMergedGroups = `{
+            "account": "test-account",
+            "projectID": "test-project-id",
+            "readGroups": [
+              "gg_test1",
+              "gg_test2"
+            ],
+            "writeGroups": [
+              "gg_test1",
+              "gg_test2"
+            ]
           }`
 
 const payloadCredentialsCreated = `{

--- a/internal/sql/client.go
+++ b/internal/sql/client.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jinzhu/gorm"
 	cloudrunner "github.com/homedepot/cloud-runner/pkg"
 
@@ -35,8 +36,6 @@ type Client interface {
 	Connection() (string, string)
 	CreateCredentials(cloudrunner.Credentials) error
 	CreateDeployment(cloudrunner.Deployment) error
-	CreateReadPermission(cloudrunner.CredentialsReadPermission) error
-	CreateWritePermission(cloudrunner.CredentialsWritePermission) error
 	DB() *gorm.DB
 	DeleteCredentials(string) error
 	GetCredentials(string) (cloudrunner.Credentials, error)
@@ -100,24 +99,44 @@ func (c *client) Connection() (string, string) {
 		c.user, c.pass, c.host, c.name)
 }
 
-// CreateCredentials inserts a new set of credentials into the DB.
+// CreateCredentials inserts a new set of credentials into the DB along with
+// its associated read/write groups. It uses a transaction, so that if any
+// operation fails the operations are rolled back.
 func (c *client) CreateCredentials(credentials cloudrunner.Credentials) error {
-	return c.db.Create(&credentials).Error
+	return c.db.Transaction(func(tx *gorm.DB) error {
+		for _, group := range credentials.ReadGroups {
+			r := cloudrunner.CredentialsReadPermission{
+				ID:        uuid.New().String(),
+				Account:   credentials.Account,
+				ReadGroup: group,
+			}
+
+			err := tx.Create(&r).Error
+			if err != nil {
+				return err
+			}
+		}
+
+		for _, group := range credentials.WriteGroups {
+			w := cloudrunner.CredentialsWritePermission{
+				ID:         uuid.New().String(),
+				Account:    credentials.Account,
+				WriteGroup: group,
+			}
+
+			err := tx.Create(&w).Error
+			if err != nil {
+				return err
+			}
+		}
+
+		return tx.Create(&credentials).Error
+	})
 }
 
 // CreateDeployment inserts a new deployment into the DB.
 func (c *client) CreateDeployment(d cloudrunner.Deployment) error {
 	return c.db.Create(&d).Error
-}
-
-// CreateReadPermission inserts a read permission into the database.
-func (c *client) CreateReadPermission(r cloudrunner.CredentialsReadPermission) error {
-	return c.db.Create(&r).Error
-}
-
-// CreateWritePermission inserts a write permission into the database.
-func (c *client) CreateWritePermission(w cloudrunner.CredentialsWritePermission) error {
-	return c.db.Create(&w).Error
 }
 
 // DB returns the underlying db.


### PR DESCRIPTION
- converts the sql client `CreateCredentials` func to use a transaction
- moves the logic to insert the groups into the DB into the SQL client
- removes the `CreateReadGroup` and `CreateWriteGroup` functions
- merges all missing write groups into read groups when creating the credentials